### PR TITLE
Fix error when parsing legacy in paper

### DIFF
--- a/core/src/main/java/de/eldoria/jacksonbukkit/deserializer/LegacyItemStackDeserializer.java
+++ b/core/src/main/java/de/eldoria/jacksonbukkit/deserializer/LegacyItemStackDeserializer.java
@@ -8,6 +8,7 @@ package de.eldoria.jacksonbukkit.deserializer;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.type.MapType;
 import de.eldoria.jacksonbukkit.entities.MapContainer;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -27,16 +28,19 @@ public class LegacyItemStackDeserializer extends JsonDeserializer<ItemStack> {
 
     @Override
     public ItemStack deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        return parseTree(ctxt.readTree(p), ctxt);
+    }
+
+    protected ItemStack parseTree(JsonNode tree, DeserializationContext ctxt) throws IOException {
         MapType type = ctxt.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
 
         YamlConfiguration yamlConfiguration = new YamlConfiguration();
         try {
-            yamlConfiguration.loadFromString(YAML.dump(new MapContainer(ctxt.readValue(p, type))));
+            yamlConfiguration.loadFromString(YAML.dump(new MapContainer(ctxt.readTreeAsValue(tree, type))));
         } catch (InvalidConfigurationException e) {
             throw new IOException(e);
         }
 
         return (ItemStack) yamlConfiguration.get("map");
     }
-
 }

--- a/paper/src/main/java/de/eldoria/jacksonbukkit/deserializer/PaperItemStackDeserializer.java
+++ b/paper/src/main/java/de/eldoria/jacksonbukkit/deserializer/PaperItemStackDeserializer.java
@@ -25,6 +25,6 @@ public class PaperItemStackDeserializer extends LegacyItemStackDeserializer {
             byte[] decode = Base64.getDecoder().decode(ctxt.readValue(p, String.class));
             return ItemStack.deserializeBytes(decode);
         }
-        return super.deserialize(p, ctxt);
+        return parseTree(tree, ctxt);
     }
 }


### PR DESCRIPTION
When parsing the legacy version in paper the cursor will be already past the object after parsing the json to a tree. therefore nothing will be returned and a null item stack will be returned.