### PR TITLE
Fix: jackson dependency has missing version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ allprojects {
     dependencies {
         api("org.jetbrains", "annotations", "24.0.1")
 
-        implementation(platform("com.fasterxml.jackson:jackson-bom:2.14.2"))
+        api(platform("com.fasterxml.jackson:jackson-bom:2.14.2"))
         api("com.fasterxml.jackson.core", "jackson-core")
         api("com.fasterxml.jackson.core:jackson-databind")
 


### PR DESCRIPTION
Importing bom as implementation hides the version when importing in other projects. This causes jackson to not be imported at all.